### PR TITLE
feat: addidng ability to pass errorsParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-ts-client",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "description": "GraphQL Typescript Client Generator",
   "author": "Wellington Guimaraes",
   "license": "MIT",

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -62,11 +62,10 @@ export const getApiEndpointCreator =
           requestHeaders,
           query,
           variables,
+          errorsParser: apiConfig.errorsParser
         })
 
-        const parsedErrors = apiConfig.errorsParser ? apiConfig.errorsParser(errors) : errors
-
-        const response = { data, warnings, headers, status, errors: parsedErrors }
+        const response = { data, warnings, headers, status, errors }
 
         if (apiConfig.verbose && globalThis.document) {
           logRequest({
@@ -81,7 +80,7 @@ export const getApiEndpointCreator =
           response,
         })
 
-        return { data: data?.[alias], errors: parsedErrors, warnings, headers, status }
+        return { data: data?.[alias], errors, warnings, headers, status }
       } catch (error) {
         if (apiConfig.verbose && globalThis.document) {
           logRequest({

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -19,6 +19,7 @@ export const getApiEndpointCreator =
     maxAge: number
     verbose: boolean
     formatGraphQL: any
+    errorsParser?: (errors: any[]) => any
   }) =>
   <I = any, O = any, E = any>(kind: 'mutation' | 'query', queryName: string): Endpoint<I, O, E> => {
     const rawEndpoint: any = async <S extends I>(
@@ -63,7 +64,9 @@ export const getApiEndpointCreator =
           variables,
         })
 
-        const response = { data, warnings, headers, status, errors }
+        const parsedErrors = apiConfig.errorsParser ? apiConfig.errorsParser(errors) : errors
+
+        const response = { data, warnings, headers, status, errors: parsedErrors }
 
         if (apiConfig.verbose && globalThis.document) {
           logRequest({
@@ -78,7 +81,7 @@ export const getApiEndpointCreator =
           response,
         })
 
-        return { data: data?.[alias], errors, warnings, headers, status }
+        return { data: data?.[alias], errors: parsedErrors, warnings, headers, status }
       } catch (error) {
         if (apiConfig.verbose && globalThis.document) {
           logRequest({

--- a/src/graphqlRequest.ts
+++ b/src/graphqlRequest.ts
@@ -15,6 +15,7 @@ export async function graphqlRequest({
   requestHeaders = {},
   variables,
   failureMode,
+  errorsParser,
 }: {
   shouldRetry?: boolean
   failureMode: 'loud' | 'silent'
@@ -24,6 +25,7 @@ export async function graphqlRequest({
   query: string
   requestHeaders?: { [_key: string]: any }
   variables: { [_key: string]: any }
+  errorsParser?: (errors: any[]) => any
 }) {
   let lastResponse: ResponseData
 
@@ -60,7 +62,7 @@ export async function graphqlRequest({
     }
 
     lastResponse = {
-      errors,
+      errors: errorsParser ? errorsParser(errors) : errors,
       data,
       warnings,
       headers,


### PR DESCRIPTION
addidng ability to pass errorsParser what could be used to filter/parse all errors from the API on the endpoint level

+ fixed issue with cache hash generation (it was incorrectly used for cases with same endpoint url but different other options)

Sample usage of errorsParser in our case:
```
        errorsParser: (errors) => {
          if(!errors || !Array.isArray(errors) || errors.length < 2 || errors[0].extensions?.code !=='SUBREQUEST_HTTP_ERROR') {
            return errors
          }
          return errors.slice(1)
        }
```

To filter out first error from apollo-router:
![image](https://github.com/wellguimaraes/graphql-ts-client/assets/4493100/7de1d365-4727-4e22-9485-03e7052146d7)
