### PR TITLE
refactor: rename the GraphQL variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avantstay/graphql-ts-client",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "description": "GraphQL Typescript Client Generator",
   "author": "Wellington Guimaraes",
   "license": "MIT",

--- a/src/jsonToGraphQLQuery.test.ts
+++ b/src/jsonToGraphQLQuery.test.ts
@@ -38,8 +38,14 @@ describe('jsonToGraphQLQuery', () => {
       __args: {
         foo: 'Bar',
       },
-
       something: true,
+      another: {
+        __args: {
+          foo: 'Lorem ipsum',
+          bar: 'Dolor sit amet',
+        },
+        zeta: true,
+      },
     }
 
     const response = jsonToGraphQLQuery({
@@ -53,14 +59,24 @@ describe('jsonToGraphQLQuery', () => {
               __args: {
                 foo: 'UUID!',
               },
+              something: 'Boolean!',
+              another: {
+                __args: {
+                  foo: 'String!',
+                  bar: 'String!',
+                },
+                zeta: 'Int!',
+              },
             }
           },
         },
       },
     })
 
-    Object.keys(response.variables).forEach(varName => {
-      expect(response.query.split(varName).length - 1).toBeGreaterThanOrEqual(2) //every variable name should be present at least 2 times
+    expect(response.variables).toEqual({
+      foo_0: 'Bar',
+      foo_1: 'Lorem ipsum',
+      bar_0: 'Dolor sit amet',
     })
   })
 })

--- a/src/jsonToGraphQLQuery.test.ts
+++ b/src/jsonToGraphQLQuery.test.ts
@@ -76,7 +76,7 @@ describe('jsonToGraphQLQuery', () => {
     expect(response.variables).toEqual({
       foo_0: 'Bar',
       foo_1: 'Lorem ipsum',
-      bar_0: 'Dolor sit amet',
+      bar: 'Dolor sit amet',
     })
   })
 })

--- a/src/jsonToGraphQLQuery.ts
+++ b/src/jsonToGraphQLQuery.ts
@@ -7,6 +7,9 @@ const fromEntries: (arr: [string, any][]) => { [key: string]: any } = require('l
 const entries: (obj: { [key: string]: any }) => [string, any][] = require('lodash/toPairs')
 const cloneDeep = require('lodash/cloneDeep')
 
+type ExtractedVariables = Record<string, (Variable & { name: string })[]>
+type Variable = { type: any; value: any }
+
 export function jsonToGraphQLQuery({
   kind,
   queryName,
@@ -18,7 +21,7 @@ export function jsonToGraphQLQuery({
   jsonQuery: any
   typesTree: any
 }) {
-  const variablesData = {} as any
+  const variablesData = {} as ExtractedVariables
   const alias = jsonQuery.__alias
   const newJsonQuery = cloneDeep(omit(jsonQuery, ['__alias', '__headers']))
 
@@ -28,8 +31,16 @@ export function jsonToGraphQLQuery({
     parentType: kind === 'query' ? typesTree.Query : typesTree.Mutation,
   })
 
-  const variablesQuery = Object.keys(variablesData).length
-    ? `(${entries(variablesData)
+  const variableItems = Object.values(variablesData).reduce((variablesObj, variables) => {
+    variables.forEach(variable => {
+      variablesObj[variable.name] = { type: variable.type, value: variable.value }
+    })
+
+    return variablesObj
+  }, {} as Record<string, Variable>)
+
+  const variablesQuery = Object.keys(variableItems).length
+    ? `(${entries(variableItems)
         .map(([queryName, { type }]: any) => `$${queryName}: ${type}`)
         .join(', ')})`
     : ''
@@ -37,7 +48,7 @@ export function jsonToGraphQLQuery({
   const query = `${kind} ${alias || queryName}${variablesQuery} { ${alias ? `${alias}:` : ''}${queryName}${toGraphql(
     newJsonQuery
   )} }`
-  const variables = fromEntries(entries(variablesData).map(([k, v]: any) => [k, v.value]))
+  const variables = fromEntries(entries(variableItems).map(([k, v]: any) => [k, v.value]))
 
   return {
     query,
@@ -45,22 +56,36 @@ export function jsonToGraphQLQuery({
   }
 }
 
-function extractVariables({ jsonQuery, variables, parentType }: { jsonQuery: any; variables: any; parentType: any }) {
+function extractVariables({
+  jsonQuery,
+  variables,
+  parentType,
+}: {
+  jsonQuery: any
+  variables: ExtractedVariables
+  parentType: any
+}) {
   if (!parentType) return
 
   if (jsonQuery.__args) {
     Object.keys(jsonQuery.__args).forEach(k => {
       if (typeof jsonQuery.__args[k] === 'string' && jsonQuery.__args[k].startsWith(VAR_PREFIX)) return
+      if (jsonQuery.__args[k] === undefined) return
 
-      const variableName = `${k}_${Math.random().toString(36).substr(2, 4)}`
+      const baseVariableName = k
 
-      if (jsonQuery.__args[k] !== undefined) {
-        variables[variableName] = {
-          type: parentType.__args[k],
-          value: jsonQuery.__args[k],
-        }
-        jsonQuery.__args[k] = `${VAR_PREFIX}$${variableName}`
+      if (!variables[baseVariableName]) {
+        variables[baseVariableName] = []
       }
+
+      const variableName = `${k}_${variables[baseVariableName].length}`
+      variables[baseVariableName].push({
+        name: variableName,
+        type: parentType.__args[k],
+        value: jsonQuery.__args[k],
+      })
+
+      jsonQuery.__args[k] = `${VAR_PREFIX}$${variableName}`
     })
   }
 


### PR DESCRIPTION
Instead of adding a random string at the end, it starts a counter and each of the same variable name increases the counter by 1.

The name of the variable is `$variable_counter`