### PR TITLE
Fix: return type should reflect optional types correctly

### DIFF
--- a/src/generateTypescriptClient.ts
+++ b/src/generateTypescriptClient.ts
@@ -152,10 +152,9 @@ function gqlEndpointToCode(kind: 'mutation' | 'query', endpoint: IntrospectionFi
   }${selectionType ? ` & ${selectionType}` : ''}`
 
   const outputType = gqlTypeToTypescript(endpoint.type, { required: true })
-  const wrappedOutputType = /^(string|number|boolean)$/.test(outputType) ? outputType : `DeepRequired<${outputType}>`
 
   return codeOutputType === 'ts'
-    ? `${endpoint.name}: Endpoint<${inputType}, ${wrappedOutputType}, AllEnums>`
+    ? `${endpoint.name}: Endpoint<${inputType}, ${outputType}, AllEnums>`
     : `${endpoint.name}: apiEndpoint('${kind}', '${endpoint.name}')`
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,11 +21,14 @@ export type IResponseListener = (info: ResponseListenerInfo) => void | Promise<v
 
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never
 
+type Primitive = Date | string | number | boolean | null | undefined
+
+// Projection is the resulting type of Selection (type generated out of a query) applied to Base (generated graphql type)
 export type Projection<Selection, Base, E = never> = Base extends Array<any>
-  ? ArrayElement<Base> extends Date | string | number | boolean | null | undefined | E
+  ? ArrayElement<Base> extends Primitive | E
     ? ArrayElement<Base>[]
     : Projection<Defined<Selection>, ArrayElement<Base>, E>[]
-  : Base extends Date | string | number | boolean | null | E
+  : Base extends Primitive | E
   ? // Is primitive and extends undefined
     Selection extends undefined
     ? Base | undefined


### PR DESCRIPTION
### Definition of the problem

Let say we have the following graphql schema: 
```graphql
type Cover {
  url: String
}

type Book {
    cover: Cover #this is an optional type
}

type Query {
    booksWithoutParams: [Book]
}
```

And the following query
```typescript
const books = await client.queries.booksWithoutParams({
      cover: { 
        url: true
      },
 })
```

The library wouldn't return that cover is possible undefined (or null) so 

`books.cover.url` would result in a crash in runtime if `cover` is null or undefined.

This pull request fixes it and the returned type of books would consider it can be undefined.