### PR TITLE
feature: add esm output files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,14 @@
 {
-  "printWidth": 100
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "ignore",
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 130,
+  "proseWrap": "always",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
 }

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ import { myAwesomeApi, AssetType, Granularity, OnBoardingStage } from './myAweso
 async function somewhereOverTheRainbow() {
   // Set an specific header if needed
   myAwesomeApi.setHeader('Authorization', 'Bearer 010101010101')
-  
+
   // You can also change the API url
   myAwesomeApi.setUrl('https://my-runtime-url.com/graphql')
-  
+
   // And configure how retrials should work
   myAwesomeApi.setRetryConfig({
     max: 3,
@@ -44,12 +44,12 @@ async function somewhereOverTheRainbow() {
       // do something before retrying
     },
   })
-  
+
   // Adding response listeners is also possible
   myAwesomeApi.addResponseListener(({ queryName, query, variables, response }) => {
     // do something whenever a request is responded
   })
-  
+
   const response = await myAwesomeApi.queries.globalIndicators({
     // Optionally you can define an alias for this request
     __alias: 'myCustomGlobalIndicators',

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  presets: [
-    ['@babel/preset-env', {targets: {node: 'current'}}],
-    '@babel/preset-typescript',
-  ],
-};
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+}

--- a/package.json
+++ b/package.json
@@ -2,56 +2,54 @@
   "name": "@avantstay/graphql-ts-client",
   "version": "10.8.0",
   "description": "GraphQL Typescript Client Generator",
-  "author": "Wellington Guimaraes",
-  "license": "MIT",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsup src/index.ts src/endpoint.ts --dts",
-    "test": "cross-env GQL_CLIENT_DIST_PATH='.' jest --watch",
-    "prepublishOnly": "yarn build"
-  },
-  "files": [
-    "dist",
-    "src"
-  ],
-  "engines": {
-    "node": ">=12"
-  },
+  "homepage": "https://github.com/avantstay/graphql-ts-client#readme",
   "bugs": {
     "url": "https://github.com/avantstay/graphql-ts-client/issues"
   },
-  "homepage": "https://github.com/avantstay/graphql-ts-client#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/avantstay/graphql-ts-client.git"
   },
-  "peerDependencies": {},
+  "license": "MIT",
+  "author": "Wellington Guimaraes",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./dist/endpoint": {
+      "import": "./dist/endpoint.mjs",
+      "require": "./dist/endpoint.js",
+      "types": "./dist/endpoint.d.ts"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/graphql-ts-client.esm.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts src/endpoint.ts --dts --format cjs,esm",
+    "prepublishOnly": "yarn build",
+    "test": "cross-env GQL_CLIENT_DIST_PATH='.' jest --watch"
+  },
   "prettier": {
-    "trailingComma": "es5",
-    "tabWidth": 2,
-    "proseWrap": "always",
+    "arrowParens": "avoid",
     "bracketSpacing": true,
+    "endOfLine": "lf",
+    "htmlWhitespaceSensitivity": "ignore",
     "jsxBracketSameLine": false,
+    "jsxSingleQuote": false,
+    "printWidth": 130,
+    "proseWrap": "always",
     "semi": false,
     "singleQuote": true,
-    "arrowParens": "avoid",
-    "endOfLine": "lf",
-    "printWidth": 130,
-    "htmlWhitespaceSensitivity": "ignore",
-    "jsxSingleQuote": false
+    "tabWidth": 2,
+    "trailingComma": "es5"
   },
-  "module": "dist/graphql-ts-client.esm.js",
-  "size-limit": [
-    {
-      "path": "dist/graphql-ts-client.cjs.production.min.js",
-      "limit": "10 KB"
-    },
-    {
-      "path": "dist/graphql-ts-client.esm.js",
-      "limit": "10 KB"
-    }
-  ],
   "dependencies": {
     "@types/md5": "^2.3.2",
     "axios": "^0.24.0",
@@ -87,7 +85,21 @@
     "tsup": "^6.5.0",
     "typescript": "^4.9.4"
   },
+  "peerDependencies": {},
+  "engines": {
+    "node": ">=12"
+  },
   "publishConfig": {
     "@avantstay:registry": "https://registry.npmjs.org/"
-  }
+  },
+  "size-limit": [
+    {
+      "path": "dist/graphql-ts-client.cjs.production.min.js",
+      "limit": "10 KB"
+    },
+    {
+      "path": "dist/graphql-ts-client.esm.js",
+      "limit": "10 KB"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -39,20 +39,6 @@
     "prepublishOnly": "yarn build",
     "test": "cross-env GQL_CLIENT_DIST_PATH='.' jest --watch"
   },
-  "prettier": {
-    "arrowParens": "avoid",
-    "bracketSpacing": true,
-    "endOfLine": "lf",
-    "htmlWhitespaceSensitivity": "ignore",
-    "jsxBracketSameLine": false,
-    "jsxSingleQuote": false,
-    "printWidth": 130,
-    "proseWrap": "always",
-    "semi": false,
-    "singleQuote": true,
-    "tabWidth": 2,
-    "trailingComma": "es5"
-  },
   "dependencies": {
     "@types/md5": "^2.3.2",
     "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@avantstay/graphql-ts-client",
   "version": "10.8.0",
   "description": "GraphQL Typescript Client Generator",
-  "homepage": "https://github.com/avantstay/graphql-ts-client#readme",
+  "homepage": "https://github.com/avantstay/graphql-ts-client",
   "bugs": {
     "url": "https://github.com/avantstay/graphql-ts-client/issues"
   },
@@ -12,6 +12,9 @@
   },
   "license": "MIT",
   "author": "Wellington Guimaraes",
+  "contributors": [
+    "Felipe Pinheiro <felipe.pinheiro.90@hotmail.com>"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -25,7 +28,7 @@
     }
   },
   "main": "dist/index.js",
-  "module": "dist/graphql-ts-client.esm.js",
+  "module": "dist/index.mjs",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avantstay/graphql-ts-client",
-  "version": "10.8.0",
+  "version": "10.9.0",
   "description": "GraphQL Typescript Client Generator",
   "homepage": "https://github.com/avantstay/graphql-ts-client",
   "bugs": {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -2,14 +2,10 @@ import memoize from 'moize'
 import { graphqlRequest } from './graphqlRequest'
 import { jsonToGraphQLQuery } from './jsonToGraphQLQuery'
 import { logRequest } from './logging'
-import {ClientConfig, Endpoint, GraphQLClientError, IResponseListener, Projection, ResponseListenerInfo} from './types'
+import { ClientConfig, Endpoint, GraphQLClientError, IResponseListener, Projection, ResponseListenerInfo } from './types'
 
 const executeListeners = (listeners: IResponseListener[], data: ResponseListenerInfo) =>
-  setTimeout(() =>
-    listeners.forEach(runResponseListener =>
-      runResponseListener(data)
-    )
-  )
+  setTimeout(() => listeners.forEach(runResponseListener => runResponseListener(data)))
 
 export const getApiEndpointCreator =
   (apiConfig: {
@@ -61,11 +57,11 @@ export const getApiEndpointCreator =
           shouldRetry,
           failureMode,
           queryName: alias,
-          client: {...clientConfig, url },
+          client: { ...clientConfig, url },
           requestHeaders,
           query,
           variables,
-          errorsParser: apiConfig.errorsParser
+          errorsParser: apiConfig.errorsParser,
         })
 
         const response = { data, warnings, headers, status, errors }
@@ -78,7 +74,7 @@ export const getApiEndpointCreator =
           })
         }
 
-        executeListeners(apiConfig.responseListeners,{
+        executeListeners(apiConfig.responseListeners, {
           ...responseListenerData,
           response,
         })

--- a/src/generateTypescriptClient.test.ts
+++ b/src/generateTypescriptClient.test.ts
@@ -125,12 +125,12 @@ describe('Generated Client', () => {
     expect(responseData?.response.errors.length).toBeGreaterThan(0)
   })
 
-  it('should generate proper code from SDL', ()=>{
+  it('should generate proper code from SDL', () => {
     const sdlString = `
   type Query {
     hello: String
   }
-`;
-    expect(generateTypescriptClientFromSDL(sdlString, {endpoint: 'https://sample.endpoint.com/graphl'})).toMatchSnapshot()
+`
+    expect(generateTypescriptClientFromSDL(sdlString, { endpoint: 'https://sample.endpoint.com/graphl' })).toMatchSnapshot()
   })
 })

--- a/src/generateTypescriptClient.ts
+++ b/src/generateTypescriptClient.ts
@@ -6,8 +6,8 @@ import * as fs from 'fs'
 import { PathLike } from 'fs'
 import {
   buildSchema,
-  graphqlSync,
   getIntrospectionQuery,
+  graphqlSync,
   IntrospectionEnumType,
   IntrospectionField,
   IntrospectionInputObjectType,
@@ -25,6 +25,7 @@ import os from 'os'
 import path from 'path'
 import * as prettier from 'prettier'
 import pkg from '../package.json'
+import { TypescriptClientOutput } from './types'
 
 const tempDir = fs.realpathSync(os.tmpdir())
 
@@ -314,7 +315,7 @@ type IClientOptions = {
   errorsParser?: (errors: any[]) => any
 }
 
-type FetchIntrospectionOptions = Omit< IClientOptions, 'output' | 'introspectionEndpoint'>
+type FetchIntrospectionOptions = Omit<IClientOptions, 'output' | 'introspectionEndpoint'>
 
 function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Omit<IClientOptions, 'output'>) {
   const typesHash = md5(`${JSON.stringify(options)}__${JSON.stringify(types)}`)
@@ -322,7 +323,11 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
   const clientCacheFilePath = path.resolve(tempDir, clientCacheFileName)
 
   if (!options.skipCache && fs.existsSync(clientCacheFilePath)) {
-    return JSON.parse(fs.readFileSync(clientCacheFilePath, { encoding: 'utf8' }))
+    const output: Partial<TypescriptClientOutput> = JSON.parse(fs.readFileSync(clientCacheFilePath, { encoding: 'utf8' }))
+
+    if (output.js && output.mjs && output.typings) {
+      return output as TypescriptClientOutput
+    }
   }
 
   const queries = (<IntrospectionObjectType>types.find(it => it.name === 'Query'))?.fields || []
@@ -472,8 +477,9 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
 
     export default ${clientName}`
 
-  const output = {
+  const output: TypescriptClientOutput = {
     js: esbuild.transformSync(jsCode, { format: 'cjs', loader: 'js' }).code,
+    mjs: esbuild.transformSync(jsCode, { format: 'esm', loader: 'js' }).code,
     typings: prettier.format(typingsCode, { semi: false, parser: 'typescript' }),
   }
 
@@ -500,7 +506,7 @@ async function fetchIntrospection({ endpoint, headers }: FetchIntrospectionOptio
         },
       }
     )
-    .catch((e) => {
+    .catch(e => {
       const errorMessage = `The GraphQL introspection request failed (${endpoint})`
       if (fs.existsSync(introspectionCacheFilePath)) {
         const cachedSchema = JSON.parse(fs.readFileSync(introspectionCacheFilePath, { encoding: 'utf8' }))
@@ -526,10 +532,11 @@ async function fetchIntrospection({ endpoint, headers }: FetchIntrospectionOptio
   return types
 }
 
-type Client = { typings: string; js: string }
-
-function generateClient(introspectionTypes: ReadonlyArray<IntrospectionType>, {output,...restOptions}: IClientOptions): Client {
-  const { js, typings } = generateClientCode(introspectionTypes, restOptions)
+function generateClient(
+  introspectionTypes: ReadonlyArray<IntrospectionType>,
+  { output, ...restOptions }: IClientOptions
+): TypescriptClientOutput {
+  const { js, mjs, typings } = generateClientCode(introspectionTypes, restOptions)
 
   if (output && typeof output === 'string') {
     const outputDir = path.dirname(output)
@@ -540,12 +547,16 @@ function generateClient(introspectionTypes: ReadonlyArray<IntrospectionType>, {o
 
     fs.writeFileSync(output.replace(/(\.(ts|js))?$/, '.d.ts'), typings, { encoding: 'utf8' })
     fs.writeFileSync(output.replace(/(\.(ts|js))?$/, '.js'), js, { encoding: 'utf8' })
+    fs.writeFileSync(output.replace(/(\.(ts|js))?$/, '.mjs'), mjs, { encoding: 'utf8' })
   }
 
-  return { js, typings }
+  return { js, mjs, typings }
 }
 
-export async function generateTypescriptClient({ introspectionEndpoint, ...options }: IClientOptions): Promise<Client> {
+export async function generateTypescriptClient({
+  introspectionEndpoint,
+  ...options
+}: IClientOptions): Promise<TypescriptClientOutput> {
   console.log(`Generating TypeScript client (name: ${options.clientName ?? 'n/a'})`)
 
   axiosRetry(axios, { retries: 5, retryDelay: retryCount => 1000 * 2 ** retryCount })
@@ -556,14 +567,14 @@ export async function generateTypescriptClient({ introspectionEndpoint, ...optio
   })
 
   return generateClient(introspectionTypes, options)
-
 }
 
-export function generateTypescriptClientFromSDL(SDL: string, options: IClientOptions): Client {
-  console.log(`Generating TypeScript client from SDL (name: ${options.clientName ?? 'n/a'})`);
+export function generateTypescriptClientFromSDL(SDL: string, options: IClientOptions): TypescriptClientOutput {
+  console.log(`Generating TypeScript client from SDL (name: ${options.clientName ?? 'n/a'})`)
 
-  const graphqlSchemaObj = buildSchema(SDL);
-  const introspectionTypes = graphqlSync(graphqlSchemaObj, new Source(getIntrospectionQuery())).data?.__schema.types as IntrospectionType[]
+  const graphqlSchemaObj = buildSchema(SDL)
+  const introspectionTypes = graphqlSync(graphqlSchemaObj, new Source(getIntrospectionQuery())).data?.__schema
+    .types as IntrospectionType[]
 
   return generateClient(introspectionTypes, options)
 }

--- a/src/graphqlRequest.test.ts
+++ b/src/graphqlRequest.test.ts
@@ -2,10 +2,10 @@ import { graphqlRequest } from './graphqlRequest'
 
 describe('GraphQLRequest', () => {
   it('Should request have proper structure', async () => {
-    let request: any;
+    let request: any
 
     const mockedAxios = {
-      post: function() {
+      post: function () {
         request = arguments
         return {
           status: 200,
@@ -19,7 +19,7 @@ describe('GraphQLRequest', () => {
       axios: mockedAxios,
       queryName: 'sampleQueryName',
       query: 'sampleQuery',
-      variables: {foo:'bar',bar:'foo'},
+      variables: { foo: 'bar', bar: 'foo' },
       client: {
         url: 'https://whatever.com',
         headers: {},
@@ -51,7 +51,6 @@ describe('GraphQLRequest', () => {
     } as any
 
     const result = await graphqlRequest({
-
       failureMode: 'loud',
       axios: mockedAxios,
       queryName: 'whatever',

--- a/src/jsonToGraphQLQuery.ts
+++ b/src/jsonToGraphQLQuery.ts
@@ -31,14 +31,17 @@ export function jsonToGraphQLQuery({
     parentType: kind === 'query' ? typesTree.Query : typesTree.Mutation,
   })
 
-  const variableItems = Object.values(variablesData).reduce((variablesObj, variables) => {
-    variables.forEach((variable, index) => {
-      const name = variable.update(variables.length > 1 ? index : undefined)
-      variablesObj[name] = { type: variable.type, value: variable.value }
-    })
+  const variableItems = Object.values(variablesData).reduce(
+    (variablesObj, variables) => {
+      variables.forEach((variable, index) => {
+        const name = variable.update(variables.length > 1 ? index : undefined)
+        variablesObj[name] = { type: variable.type, value: variable.value }
+      })
 
-    return variablesObj
-  }, {} as Record<string, Variable>)
+      return variablesObj
+    },
+    {} as Record<string, Variable>
+  )
 
   const variablesQuery = Object.keys(variableItems).length
     ? `(${entries(variableItems)

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,12 @@ export type LogInfo = {
   duration: number
 }
 
+export type TypescriptClientOutput = {
+  js: string
+  mjs: string
+  typings: string
+}
+
 export class GraphQLClientError extends Error {
   responseData: ResponseData
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,30 +24,31 @@ type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends read
 type Primitive = Date | string | number | boolean | null | undefined
 
 // Projection is the resulting type of Selection (type generated out of a query) applied to Base (generated graphql type)
-export type Projection<Selection, Base, E = never> = Base extends Array<any>
-  ? ArrayElement<Base> extends Primitive | E
-    ? ArrayElement<Base>[]
-    : Projection<Defined<Selection>, ArrayElement<Base>, E>[]
-  : Base extends Primitive | E
-  ? // Is primitive and extends undefined
-    Selection extends undefined
-    ? Base | undefined
-    : Base
-  : {
-      [k in keyof Selection & keyof Base]: Selection[k] extends boolean
-        ? Base[k]
-        : Base[k] extends Array<infer A>
-        ? Projection<Defined<Selection[k]>, A, E>[]
-        : Projection<Defined<Selection[k]>, Base[k], E>
-    }
+export type Projection<Selection, Base, E = never> =
+  Base extends Array<any>
+    ? ArrayElement<Base> extends Primitive | E
+      ? ArrayElement<Base>[]
+      : Projection<Defined<Selection>, ArrayElement<Base>, E>[]
+    : Base extends Primitive | E
+      ? // Is primitive and extends undefined
+        Selection extends undefined
+        ? Base | undefined
+        : Base
+      : {
+          [k in keyof Selection & keyof Base]: Selection[k] extends boolean
+            ? Base[k]
+            : Base[k] extends Array<infer A>
+              ? Projection<Defined<Selection[k]>, A, E>[]
+              : Projection<Defined<Selection[k]>, Base[k], E>
+        }
 
 export type Unpacked<T> = T extends (infer U)[]
   ? U
   : T extends (...args: any[]) => infer U
-  ? U
-  : T extends Promise<infer U>
-  ? U
-  : T
+    ? U
+    : T extends Promise<infer U>
+      ? U
+      : T
 
 export type Replacement<M extends [any, any], T> = M extends any ? ([T] extends [M[0]] ? M[1] : never) : never
 
@@ -59,8 +60,8 @@ export type DeepReplace<T, Ignore, M extends [any, any]> = {
         : T[P]
       : Replacement<M, T[P]>
     : T[P] extends object
-    ? DeepReplace<T[P], Ignore, M>
-    : T[P]
+      ? DeepReplace<T[P], Ignore, M>
+      : T[P]
 }
 
 export type RawEndpoint<I, O, E> = <S extends I>(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src" ],
+  "include": ["src"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],


### PR DESCRIPTION
When generating a client code, it's also going to generate a `.mjs` file to be used on ESM projects.

Aside from this main feature, other minor improvements:

- Move prettier configuration from `package.json` to `.prettierrc`
- Execute prettier on the project
- Sort fields on `package.json` using [sort-package-json](https://www.npmjs.com/package/sort-package-json)