### PR TITLE
feat: add request listeners with mutable headers support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avantstay/graphql-ts-client",
-  "version": "12.0.2",
+  "version": "12.1.0",
   "description": "GraphQL Typescript Client Generator",
   "homepage": "https://github.com/avantstay/graphql-ts-client",
   "bugs": {

--- a/src/__snapshots__/generateTypescriptClient.test.ts.snap
+++ b/src/__snapshots__/generateTypescriptClient.test.ts.snap
@@ -29,7 +29,7 @@ __export(exports, {
   client: () => client,
   default: () => stdin_default
 });
-var import_endpoint = __toModule(require("./endpoint"));
+var import_endpoint = __toModule(require("@avantstay/graphql-ts-client/dist/endpoint"));
 const formatGraphQL = (query) => query;
 const typesTree = {};
 let verbose = false;
@@ -40,10 +40,12 @@ let retryConfig = {
   before: void 0,
   waitBeforeRetry: 0
 };
+let requestListeners = [];
 let responseListeners = [];
 let errorsParser = void 0;
 let apiEndpoint = (0, import_endpoint.getApiEndpointCreator)({
   getClient: () => ({ url, headers, retryConfig }),
+  requestListeners,
   responseListeners,
   maxAge: 3e4,
   verbose,
@@ -52,6 +54,7 @@ let apiEndpoint = (0, import_endpoint.getApiEndpointCreator)({
   errorsParser
 });
 const client = {
+  addRequestListener: (listener) => requestListeners.push(listener),
   addResponseListener: (listener) => responseListeners.push(listener),
   setHeader: (key, value) => {
     headers[key] = value;
@@ -77,7 +80,7 @@ const client = {
 };
 var stdin_default = client;
 ",
-  "mjs": "import { getApiEndpointCreator } from "./endpoint";
+  "mjs": "import { getApiEndpointCreator } from "@avantstay/graphql-ts-client/dist/endpoint";
 const formatGraphQL = (query) => query;
 const typesTree = {};
 let verbose = false;
@@ -88,10 +91,12 @@ let retryConfig = {
   before: void 0,
   waitBeforeRetry: 0
 };
+let requestListeners = [];
 let responseListeners = [];
 let errorsParser = void 0;
 let apiEndpoint = getApiEndpointCreator({
   getClient: () => ({ url, headers, retryConfig }),
+  requestListeners,
   responseListeners,
   maxAge: 3e4,
   verbose,
@@ -100,6 +105,7 @@ let apiEndpoint = getApiEndpointCreator({
   errorsParser
 });
 const client = {
+  addRequestListener: (listener) => requestListeners.push(listener),
   addResponseListener: (listener) => responseListeners.push(listener),
   setHeader: (key, value) => {
     headers[key] = value;
@@ -131,7 +137,12 @@ export {
 ",
   "typings": "// noinspection TypeScriptUnresolvedVariable, ES6UnusedImports, JSUnusedLocalSymbols, TypeScriptCheckImport
 import { DeepRequired } from "ts-essentials"
-import { Maybe, IResponseListener, Endpoint } from "."
+import {
+  Maybe,
+  IRequestListener,
+  IResponseListener,
+  Endpoint,
+} from "@avantstay/graphql-ts-client/dist"
 
 // Scalars
 export type IDate = string | Date
@@ -156,6 +167,7 @@ export interface Query {
 // Selection Types
 
 export declare const client: {
+  addRequestListener: (listener: IRequestListener) => void
   addResponseListener: (listener: IResponseListener) => void
   setHeader: (key: string, value: string) => void
   setHeaders: (newHeaders: { [k: string]: string }) => void

--- a/src/__testClient.mjs
+++ b/src/__testClient.mjs
@@ -1,4 +1,4 @@
-import { getApiEndpointCreator } from "./endpoint";
+import { getApiEndpointCreator } from "@avantstay/graphql-ts-client/dist/endpoint";
 import { format as formatCode } from "prettier/standalone";
 import parserGraphql from "prettier/parser-graphql";
 const formatGraphQL = (query) => formatCode(query, { parser: "graphql", plugins: [parserGraphql] });
@@ -41,10 +41,12 @@ let retryConfig = {
   before: void 0,
   waitBeforeRetry: 0
 };
+let requestListeners = [];
 let responseListeners = [];
 let errorsParser = void 0;
 let apiEndpoint = getApiEndpointCreator({
   getClient: () => ({ url, headers, retryConfig }),
+  requestListeners,
   responseListeners,
   maxAge: 3e4,
   verbose,
@@ -53,6 +55,7 @@ let apiEndpoint = getApiEndpointCreator({
   errorsParser
 });
 const myApiClient = {
+  addRequestListener: (listener) => requestListeners.push(listener),
   addResponseListener: (listener) => responseListeners.push(listener),
   setHeader: (key, value) => {
     headers[key] = value;

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -2,7 +2,15 @@ import memoize from 'moize'
 import { graphqlRequest } from './graphqlRequest'
 import { jsonToGraphQLQuery } from './jsonToGraphQLQuery'
 import { logRequest } from './logging'
-import { ClientConfig, Endpoint, GraphQLClientError, IResponseListener, Projection, ResponseListenerInfo } from './types'
+import {
+  ClientConfig,
+  Endpoint,
+  GraphQLClientError,
+  IRequestListener,
+  IResponseListener,
+  Projection,
+  ResponseListenerInfo,
+} from './types'
 
 const executeListeners = (listeners: IResponseListener[], data: ResponseListenerInfo) =>
   setTimeout(() => listeners.forEach(runResponseListener => runResponseListener(data)))
@@ -10,6 +18,7 @@ const executeListeners = (listeners: IResponseListener[], data: ResponseListener
 export const getApiEndpointCreator =
   (apiConfig: {
     getClient: () => ClientConfig
+    requestListeners: IRequestListener[]
     responseListeners: IResponseListener[]
     typesTree: any
     maxAge: number
@@ -28,10 +37,7 @@ export const getApiEndpointCreator =
       headers: any
       status: any
     }> => {
-      const clientConfig = apiConfig.getClient()
-
       const alias = (jsonQuery as any)?.__alias ?? queryName
-      const url = (jsonQuery as any)?.__url ?? clientConfig.url
       const shouldRetry = (jsonQuery as any)?.__retry ?? true
       const requestHeaders = (jsonQuery as any)?.__headers ?? {}
       const { query, variables } = jsonToGraphQLQuery({ kind, queryName, jsonQuery, typesTree: apiConfig.typesTree })
@@ -46,11 +52,17 @@ export const getApiEndpointCreator =
         variables,
       }
 
-      const responseListenerData = {
+      const listenerData = {
         queryName: alias,
         query: apiConfig.formatGraphQL(query),
         variables,
+        headers: { ...requestHeaders },
       }
+
+      await Promise.all(apiConfig.requestListeners.map(listener => listener(listenerData)))
+
+      const clientConfig = apiConfig.getClient()
+      const url = (jsonQuery as any)?.__url ?? clientConfig.url
 
       try {
         const { data, errors, warnings, headers, status } = await graphqlRequest({
@@ -58,7 +70,7 @@ export const getApiEndpointCreator =
           failureMode,
           queryName: alias,
           client: { ...clientConfig, url },
-          requestHeaders,
+          requestHeaders: listenerData.headers,
           query,
           variables,
           errorsParser: apiConfig.errorsParser,
@@ -75,7 +87,7 @@ export const getApiEndpointCreator =
         }
 
         executeListeners(apiConfig.responseListeners, {
-          ...responseListenerData,
+          ...listenerData,
           response,
         })
 
@@ -90,7 +102,7 @@ export const getApiEndpointCreator =
         }
 
         executeListeners(apiConfig.responseListeners, {
-          ...responseListenerData,
+          ...listenerData,
           response: (error as GraphQLClientError).response,
         })
 

--- a/src/generateTypescriptClient.test.ts
+++ b/src/generateTypescriptClient.test.ts
@@ -2,7 +2,7 @@ import { ApolloServer } from 'apollo-server'
 import * as path from 'path'
 import { generateTypescriptClient, generateTypescriptClientFromSDL } from './generateTypescriptClient'
 import { startServer } from './testServer'
-import { GraphQLClientError, ResponseListenerInfo } from './types'
+import { RequestListenerInfo, ResponseListenerInfo } from './types'
 
 let testServer: { server: ApolloServer; url: string }
 let client: any
@@ -77,7 +77,7 @@ describe('Generated Client', () => {
         (err: any) => err
       )
 
-    expect(result).toBeInstanceOf(GraphQLClientError)
+    expect(result.constructor.name).toContain('GraphQLClientError')
     expect(result.message).toBe('Failed lorem ipsum dolor')
   })
 
@@ -107,6 +107,53 @@ describe('Generated Client', () => {
     }
 
     expect(failed).toBe(true)
+  })
+
+  it('request listener is called before the request', async () => {
+    let requestData: RequestListenerInfo | undefined
+    client.addRequestListener((data: any) => (requestData = data))
+
+    await client.queries.booksWithoutParams({ title: true })
+
+    expect(requestData?.queryName).toBe('booksWithoutParams')
+    expect(requestData?.query).toBeDefined()
+    expect(requestData?.variables).toBeDefined()
+  })
+
+  it('header set in request listener is sent with the request', async () => {
+    const axios = require('axios')
+    const axiosSpy = jest.spyOn(axios, 'post')
+
+    client.addRequestListener(async () => {
+      const token = await Promise.resolve('my-fresh-token')
+      client.setHeader('Authorization', `Bearer ${token}`)
+    })
+
+    await client.queries.booksWithoutParams({ title: true })
+
+    expect(axiosSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-fresh-token',
+        }),
+      })
+    )
+
+    axiosSpy.mockRestore()
+    client.setHeader('Authorization', undefined)
+  })
+
+  it('request listener is called even for failing operations', async () => {
+    let requestData: RequestListenerInfo | undefined
+    client.addRequestListener((data: any) => (requestData = data))
+
+    try {
+      await client.queries.failingQuery({ __args: { id: 'hello' } })
+    } catch {}
+
+    expect(requestData?.queryName).toBe('failingQuery')
   })
 
   it('failing operations throw errors', async () => {

--- a/src/generateTypescriptClient.ts
+++ b/src/generateTypescriptClient.ts
@@ -376,11 +376,13 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
       before: undefined,
       waitBeforeRetry: 0
     }
+    let requestListeners = []
     let responseListeners = []
     let errorsParser = ${options.errorsParser}
     // noinspection JSUnusedLocalSymbols
     let apiEndpoint = getApiEndpointCreator({
       getClient: () => ({ url, headers, retryConfig }),
+      requestListeners,
       responseListeners,
       maxAge: 30000,
       verbose,
@@ -390,6 +392,7 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
     })
 
     export const ${clientName} = {
+      addRequestListener: (listener) => requestListeners.push(listener),
       addResponseListener: (listener) => responseListeners.push(
         listener),
       setHeader: (key, value) => {
@@ -424,7 +427,7 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
   const typingsCode = `
     // noinspection TypeScriptUnresolvedVariable, ES6UnusedImports, JSUnusedLocalSymbols, TypeScriptCheckImport
     import { DeepRequired } from 'ts-essentials'
-    import { Maybe, IResponseListener, Endpoint } from '${graphqlTsClientPath}'
+    import { Maybe, IRequestListener, IResponseListener, Endpoint } from '${graphqlTsClientPath}'
 
     // Scalars
     export type IDate = string | Date
@@ -461,6 +464,7 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
       .join('\n')}
     
     export declare const ${clientName}: {
+      addRequestListener: (listener: IRequestListener) => void
       addResponseListener: (listener: IResponseListener) => void
       setHeader: (key: string, value: string) => void
       setHeaders: (newHeaders: { [k: string]: string }) => void,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ export type ResponseData = {
   }[]
 }
 
+export type RequestListenerInfo = {
+  queryName: string
+  query: string
+  variables: any
+  headers: { [key: string]: string }
+}
+export type IRequestListener = (info: RequestListenerInfo) => void | Promise<void>
+
 export type ResponseListenerInfo = {
   queryName: string
   query: string


### PR DESCRIPTION
## Summary
- Add request listener support (`addRequestListener`) mirroring the existing `addResponseListener` pattern
- Request listeners run before each request and receive query name, query, variables, and mutable headers
- Headers modified in a request listener are sent with the outgoing request, enabling use cases like auth token refresh
- Fix `GraphQLClientError` instanceof check in tests (bundler renames the constructor)
