### PR TITLE
feat: add support for removing request and response listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avantstay/graphql-ts-client",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "description": "GraphQL Typescript Client Generator",
   "homepage": "https://github.com/avantstay/graphql-ts-client",
   "bugs": {

--- a/src/__snapshots__/generateTypescriptClient.test.ts.snap
+++ b/src/__snapshots__/generateTypescriptClient.test.ts.snap
@@ -54,8 +54,32 @@ let apiEndpoint = (0, import_endpoint.getApiEndpointCreator)({
   errorsParser
 });
 const client = {
-  addRequestListener: (listener) => requestListeners.push(listener),
-  addResponseListener: (listener) => responseListeners.push(listener),
+  addRequestListener: (listener) => {
+    requestListeners.push(listener);
+    return () => {
+      const index = requestListeners.indexOf(listener);
+      if (index > -1)
+        requestListeners.splice(index, 1);
+    };
+  },
+  removeRequestListener: (listener) => {
+    const index = requestListeners.indexOf(listener);
+    if (index > -1)
+      requestListeners.splice(index, 1);
+  },
+  addResponseListener: (listener) => {
+    responseListeners.push(listener);
+    return () => {
+      const index = responseListeners.indexOf(listener);
+      if (index > -1)
+        responseListeners.splice(index, 1);
+    };
+  },
+  removeResponseListener: (listener) => {
+    const index = responseListeners.indexOf(listener);
+    if (index > -1)
+      responseListeners.splice(index, 1);
+  },
   setHeader: (key, value) => {
     headers[key] = value;
   },
@@ -105,8 +129,32 @@ let apiEndpoint = getApiEndpointCreator({
   errorsParser
 });
 const client = {
-  addRequestListener: (listener) => requestListeners.push(listener),
-  addResponseListener: (listener) => responseListeners.push(listener),
+  addRequestListener: (listener) => {
+    requestListeners.push(listener);
+    return () => {
+      const index = requestListeners.indexOf(listener);
+      if (index > -1)
+        requestListeners.splice(index, 1);
+    };
+  },
+  removeRequestListener: (listener) => {
+    const index = requestListeners.indexOf(listener);
+    if (index > -1)
+      requestListeners.splice(index, 1);
+  },
+  addResponseListener: (listener) => {
+    responseListeners.push(listener);
+    return () => {
+      const index = responseListeners.indexOf(listener);
+      if (index > -1)
+        responseListeners.splice(index, 1);
+    };
+  },
+  removeResponseListener: (listener) => {
+    const index = responseListeners.indexOf(listener);
+    if (index > -1)
+      responseListeners.splice(index, 1);
+  },
   setHeader: (key, value) => {
     headers[key] = value;
   },
@@ -167,8 +215,10 @@ export interface Query {
 // Selection Types
 
 export declare const client: {
-  addRequestListener: (listener: IRequestListener) => void
-  addResponseListener: (listener: IResponseListener) => void
+  addRequestListener: (listener: IRequestListener) => () => void
+  removeRequestListener: (listener: IRequestListener) => void
+  addResponseListener: (listener: IResponseListener) => () => void
+  removeResponseListener: (listener: IResponseListener) => void
   setHeader: (key: string, value: string) => void
   setHeaders: (newHeaders: { [k: string]: string }) => void
   setUrl: (url: string) => void

--- a/src/__testClient.mjs
+++ b/src/__testClient.mjs
@@ -55,8 +55,32 @@ let apiEndpoint = getApiEndpointCreator({
   errorsParser
 });
 const myApiClient = {
-  addRequestListener: (listener) => requestListeners.push(listener),
-  addResponseListener: (listener) => responseListeners.push(listener),
+  addRequestListener: (listener) => {
+    requestListeners.push(listener);
+    return () => {
+      const index = requestListeners.indexOf(listener);
+      if (index > -1)
+        requestListeners.splice(index, 1);
+    };
+  },
+  removeRequestListener: (listener) => {
+    const index = requestListeners.indexOf(listener);
+    if (index > -1)
+      requestListeners.splice(index, 1);
+  },
+  addResponseListener: (listener) => {
+    responseListeners.push(listener);
+    return () => {
+      const index = responseListeners.indexOf(listener);
+      if (index > -1)
+        responseListeners.splice(index, 1);
+    };
+  },
+  removeResponseListener: (listener) => {
+    const index = responseListeners.indexOf(listener);
+    if (index > -1)
+      responseListeners.splice(index, 1);
+  },
   setHeader: (key, value) => {
     headers[key] = value;
   },

--- a/src/generateTypescriptClient.test.ts
+++ b/src/generateTypescriptClient.test.ts
@@ -172,6 +172,56 @@ describe('Generated Client', () => {
     expect(responseData?.response.errors.length).toBeGreaterThan(0)
   })
 
+  it('removeRequestListener removes a previously added request listener', async () => {
+    let callCount = 0
+    const listener = () => { callCount++ }
+
+    client.addRequestListener(listener)
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+
+    client.removeRequestListener(listener)
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+  })
+
+  it('removeResponseListener removes a previously added response listener', async () => {
+    let callCount = 0
+    const listener = () => { callCount++ }
+
+    client.addResponseListener(listener)
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+
+    client.removeResponseListener(listener)
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+  })
+
+  it('addRequestListener returns an unsubscribe function', async () => {
+    let callCount = 0
+    const unsubscribe = client.addRequestListener(() => { callCount++ })
+
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+
+    unsubscribe()
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+  })
+
+  it('addResponseListener returns an unsubscribe function', async () => {
+    let callCount = 0
+    const unsubscribe = client.addResponseListener(() => { callCount++ })
+
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+
+    unsubscribe()
+    await client.queries.booksWithoutParams({ title: true })
+    expect(callCount).toBe(1)
+  })
+
   it('should generate proper code from SDL', () => {
     const sdlString = `
   type Query {

--- a/src/generateTypescriptClient.ts
+++ b/src/generateTypescriptClient.ts
@@ -392,9 +392,28 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
     })
 
     export const ${clientName} = {
-      addRequestListener: (listener) => requestListeners.push(listener),
-      addResponseListener: (listener) => responseListeners.push(
-        listener),
+      addRequestListener: (listener) => {
+        requestListeners.push(listener)
+        return () => {
+          const index = requestListeners.indexOf(listener)
+          if (index > -1) requestListeners.splice(index, 1)
+        }
+      },
+      removeRequestListener: (listener) => {
+        const index = requestListeners.indexOf(listener)
+        if (index > -1) requestListeners.splice(index, 1)
+      },
+      addResponseListener: (listener) => {
+        responseListeners.push(listener)
+        return () => {
+          const index = responseListeners.indexOf(listener)
+          if (index > -1) responseListeners.splice(index, 1)
+        }
+      },
+      removeResponseListener: (listener) => {
+        const index = responseListeners.indexOf(listener)
+        if (index > -1) responseListeners.splice(index, 1)
+      },
       setHeader: (key, value) => {
         headers[key] = value
       },
@@ -464,8 +483,10 @@ function generateClientCode(types: ReadonlyArray<IntrospectionType>, options: Om
       .join('\n')}
     
     export declare const ${clientName}: {
-      addRequestListener: (listener: IRequestListener) => void
-      addResponseListener: (listener: IResponseListener) => void
+      addRequestListener: (listener: IRequestListener) => () => void
+      removeRequestListener: (listener: IRequestListener) => void
+      addResponseListener: (listener: IResponseListener) => () => void
+      removeResponseListener: (listener: IResponseListener) => void
       setHeader: (key: string, value: string) => void
       setHeaders: (newHeaders: { [k: string]: string }) => void,
       setUrl: (url: string) => void,


### PR DESCRIPTION
## Summary
- Add `removeRequestListener` and `removeResponseListener` methods to the generated client
- `addRequestListener` and `addResponseListener` now return an unsubscribe function as an alternative way to remove listeners
- Updated TypeScript typings to reflect the new API